### PR TITLE
Enable RSA signatures, remove bit length reporting, dep cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.4.0"
-ssh-key = { version = "0.5.1", features = ["ed25519", "dsa", "ecdsa", "rsa"] }
+ssh-key = { version = "0.5.1", features = ["rsa", "dsa", "ed25519", "ecdsa"] }
 ssh-encoding = "0.1.0"
 hexdump = "0.1.1"
 # we need the signature that ssh-key uses

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,6 +1,5 @@
 use ssh_agent_client_rs::{Client, Result};
-use ssh_key::public::{KeyData, PublicKey};
-use ssh_key::{EcdsaCurve, MPInt};
+use ssh_key::public::PublicKey;
 use std::env;
 use std::path::Path;
 
@@ -21,31 +20,9 @@ fn main() -> Result<()> {
 
 fn print(key: &PublicKey) {
     println!(
-        "{} {} {} {}",
-        key_bits(&key),
+        "{} {} {}",
         key.fingerprint(Default::default()),
         key.comment(),
         key.algorithm().to_string(),
     )
-}
-
-/// Returns the key size in bits for different PublicKey variants.
-fn key_bits(key: &PublicKey) -> usize {
-    match key.key_data() {
-        KeyData::Rsa(k) => get_bits(&k.n),
-        KeyData::Dsa(k) => get_bits(&k.p),
-        KeyData::Ed25519(k) => k.0.len() * 8,
-        KeyData::Ecdsa(k) => match k.curve() {
-            EcdsaCurve::NistP256 => 256,
-            EcdsaCurve::NistP384 => 384,
-            EcdsaCurve::NistP521 => 521,
-        },
-        KeyData::SkEcdsaSha2NistP256(_) => 256,
-        KeyData::SkEd25519(k) => k.public_key().0.len() * 8,
-        _ => panic!("Unrecognised key {:?}", key),
-    }
-}
-
-fn get_bits(int: &MPInt) -> usize {
-    return int.as_positive_bytes().expect("should be positive").len() * 8;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,8 @@ impl Client {
         self.expect_success()
     }
 
-    /// Sign bytes with the given public_key
+    /// Sign bytes with the given public_key. For now, sign requests with RSA
+    /// keys are hard coded to use the SHA-512 hash algorithm.
     pub fn sign(&mut self, key: &PublicKey, data: Bytes) -> Result<Signature> {
         write_message(&mut self.socket, WriteMessage::Sign(key, data))?;
         match read_message(&mut self.socket)? {


### PR DESCRIPTION
* To generate reasonable RSA signatures, a flag needs to be added to the sign request to update to a non-broken digest algorithm
* Remove the code that prints key lengths in examples/add.rs as this depends on an API that is going away in the next release of ssh-key
* Remove some deps that are no longer used