### PR TITLE
Update all deps to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,11 @@ Pure rust implementation of the ssh-agent protocol. It can be used to write clie
 edition = "2021"
 
 [dependencies]
-bytes = "1.4.0"
-ssh-key = { version = "0.5.1", features = ["rsa", "dsa", "ed25519", "ecdsa", "p256", "p384"] }
-ssh-encoding = "0.1.0"
-# we need the signature that ssh-key uses
-signature = "1.6.4"
-thiserror = "1.0.44"
+bytes = "1.5.0"
+ssh-key = { version = "0.6.1", features = ["crypto"] }
+ssh-encoding = "0.2.0"
+signature = "2.1.0"
+thiserror = "1.0.49"
 
 [dev-dependencies]
-getrandom = "0.2.9"
+getrandom = "0.2.10"

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     /// An operation returned a ssh_key::Error wrapped in this variant.
     #[error("An ssh key operation failed")]
     SSHKey(#[from] ssh_key::Error),
+    #[error("An ssh encoding operation failed")]
+    SSHEncoding(#[from] ssh_encoding::Error),
     #[error("The remote ssh agent returned the failure message")]
     /// An operation returned the Failure message from the remote ssh-agent.
     RemoteFailure,


### PR DESCRIPTION
The new version of ssh-encoding returns ssh_encoding::Error so ensure that we can encapsulate that error as well