### PR TITLE
add implementation for windows git-bash

### DIFF
--- a/.github/workflows/rust_win_git_bash.yml
+++ b/.github/workflows/rust_win_git_bash.yml
@@ -1,0 +1,33 @@
+name: Rust_win_git_bash
+
+on:
+  push:
+    branches: [ "win_git_bash" ]
+  pull_request:
+    branches: [ "win_git_bash" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose --target x86_64-pc-windows-gnu
+    - name: Run tests
+      run: cargo test --verbose --target x86_64-pc-windows-gnu
+    - name: Format check
+      run: cargo fmt --check
+    - name: Clippy check
+      run: cargo clippy --no-deps --target x86_64-pc-windows-gnu

--- a/.github/workflows/rust_win_git_bash.yml
+++ b/.github/workflows/rust_win_git_bash.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ ssh-key = { version = "0.6.4", features = ["crypto"] }
 ssh-encoding = "0.2.0"
 signature = "2.2.0"
 thiserror = "1.0.57"
+regex="1.11.1"
+sscanf = "0.4.2"
 
 [dev-dependencies]
 getrandom = "0.2.12"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,22 @@ The following features have not yet been implemented
 The example code in examples should be pretty easy to follow.
 The basic idea is to create a `Client` instance and call its public methods to interact with the ssh-agent.
 
+## Windows git-bash
+
+The implementation of ssh-agent in git-bash works over Tcp socket and is supported by this client.  
+The rust target is x86_64-pc-windows-gnu and can be cross-compiled from Linux to Windows.  
+Windows git-bash environment has also other names: cygwin, msys2, mingW64, git-for-windows, ...  
+
+Windows has other not compatible ssh-agent implementations that are NOT supported by this client.  
+
+* Microsoft ssh works over named pipes.
+* After 2019 Microsoft introduced Unix Sockets.
+* Old and obsolete msys or msysGit
+
 ## License
 
 Licensed under either of
+
 * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 * [MIT license](http://opensource.org/licenses/MIT)
   at your option.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -162,7 +162,7 @@ mod test {
     use ssh_key::{PrivateKey, PublicKey};
     use std::io::Cursor;
 
-    pub fn reader(data: &'static [u8]) -> Cursor<&[u8]> {
+    pub fn reader(data: &'static [u8]) -> Cursor<&'static [u8]> {
         Cursor::new(&data[..])
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     /// There was a failure parsing the message
     #[error("An invalid message was received: {0}")]
     InvalidMessage(String),
+    /// There was a failure connecting to git-bash ssh-agent
+    #[error("Connection to git-bash ssh-agent error: {0}")]
+    GitBashErrorMessage(String),
     /// There was an io::Error communicating with the agent
     #[error("An error occurred communicating with the agent")]
     AgentCommunicationError(#[from] std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,14 @@
 use crate::codec::{read_message, write_message, ReadMessage, WriteMessage};
 use ssh_key::{PrivateKey, PublicKey, Signature};
 use std::io::{Read, Write};
+
+// conditional compilation: differences between unix-like and 'windows git-bash'
+#[cfg(target_family = "unix")]
 use std::os::unix::net::UnixStream;
+// git-bash works with TcpStream instead of UnixStream and has a strange handshaking
+#[cfg(target_family = "windows")]
+use std::net::TcpStream;
+
 use std::path::Path;
 
 mod codec;
@@ -40,10 +47,14 @@ pub struct Client {
     socket: Box<dyn ReadWrite>,
 }
 
+#[cfg(target_family = "unix")]
 impl ReadWrite for UnixStream {}
+#[cfg(target_family = "windows")]
+impl ReadWrite for TcpStream {}
 
 impl Client {
     /// Constructs a Client connected to a unix socket referenced by path.
+    #[cfg(target_family = "unix")]
     pub fn connect(path: &Path) -> Result<Client> {
         let socket = Box::new(UnixStream::connect(path)?);
         Ok(Client { socket })
@@ -101,6 +112,129 @@ impl Client {
             ReadMessage::Failure => Err(Error::RemoteFailure),
             _ => Err(Error::InvalidMessage("Unexpected response".to_string())),
         }
+    }
+
+    /// Constructs a Client connected to a tcp socket for 'windows git-bash'
+    ///
+    /// On Windows, git-for-windows, git-bash, cygwin, msysgit, msys2 and mingW64 provide functionality similar to a Linux distribution.  
+    /// Linux uses UnixStream, but Windows before 2019 didn't have UDS 'Unix Domain Socket'.  
+    /// Windows "git-bash" needed a different way for "ssh-add" (client) and "ssh-agent" (server) for inter process communication.  
+    /// They invented a special protocol and use the Tcp Socket instead of Unix Socket.  
+    /// <https://stackoverflow.com/questions/23086038/what-mechanism-is-used-by-msys-cygwin-to-emulate-unix-domain-sockets>
+    /// <https://github.com/abourget/secrets-bridge/blob/master/pkg/agentfwd/agentconn_windows.go>
+    #[cfg(target_family = "windows")]
+    pub fn connect(path: &Path) -> Result<Client> {
+        // ssh-agent exports the env variable SSH_AUTH_SOCK. This is normally the paths to the Unix Socket.
+        // In 'windows git-bash' the fake unix domain socket path is just a normal file
+        // that contains some data for the tcp connection")
+        let conn_string = std::fs::read_to_string(path)?;
+
+        // region: parse the SSH_AUTH_SOCK metadata
+        // example: !<socket >49722 s 09B97624-72E2CDC5-38596B86-E9F0B690\0
+        let conn_string = conn_string
+            .trim_start_matches("!<socket >")
+            .trim_end_matches("\0");
+        let mut split_iter = conn_string.split_whitespace();
+        let tcp_port = split_iter.next().ok_or_else(|| {
+            Error::GitBashErrorMessage("Bad format in ssh agent connection file.".to_string())
+        })?;
+        let is_cygwin = split_iter.next().ok_or_else(|| {
+            Error::GitBashErrorMessage("Bad format in ssh agent connection file.".to_string())
+        })?;
+        let key_guid = split_iter.next().ok_or_else(|| {
+            Error::GitBashErrorMessage("Bad format in ssh agent connection file.".to_string())
+        })?;
+        if is_cygwin != "s" {
+            return Err(Error::GitBashErrorMessage(
+                "Old version of MSysGit ssh-agent implementation is not supported.".to_string(),
+            ));
+        }
+        // endregion: parse the SSH_AUTH_SOCK metadata
+
+        // The character 's' defines the newer version of MSys2 or cygwin or mingw64.
+        // This ssh-agent implementation is supported.
+        let tcp_address = format!("localhost:{}", tcp_port);
+        let mut tcp_stream = std::net::TcpStream::connect(&tcp_address)?;
+
+        // region: mixing bytes for the handshake
+        let mut b1: [u8; 16] = [0; 16];
+        let parsed_into_bytes = sscanf::sscanf!(key_guid, "{u8:x}{u8:x}{u8:x}{u8:x}-{u8:x}{u8:x}{u8:x}{u8:x}-{u8:x}{u8:x}{u8:x}{u8:x}-{u8:x}{u8:x}{u8:x}{u8:x}")
+        .or_else(|_| Err(Error::GitBashErrorMessage("Bad format in ssh agent connection file.".to_string())))?;
+
+        b1[3] = parsed_into_bytes.0;
+        b1[2] = parsed_into_bytes.1;
+        b1[1] = parsed_into_bytes.2;
+        b1[0] = parsed_into_bytes.3;
+
+        b1[7] = parsed_into_bytes.4;
+        b1[6] = parsed_into_bytes.5;
+        b1[5] = parsed_into_bytes.6;
+        b1[4] = parsed_into_bytes.7;
+
+        b1[11] = parsed_into_bytes.8;
+        b1[10] = parsed_into_bytes.9;
+        b1[9] = parsed_into_bytes.10;
+        b1[8] = parsed_into_bytes.11;
+
+        b1[15] = parsed_into_bytes.12;
+        b1[14] = parsed_into_bytes.13;
+        b1[13] = parsed_into_bytes.14;
+        b1[12] = parsed_into_bytes.15;
+        // endregion: mixing bytes for the handshake
+
+        let _amount = tcp_stream.write(&b1)?;
+
+        let mut b2: [u8; 16] = [0; 16];
+        let _amount = tcp_stream.read(&mut b2)?;
+
+        // Preparing pid,gid,uid
+        let mut pid_uid_gid: [u8; 12] = [0; 12];
+        let pid = std::process::id();
+        // convert to LittleEndian
+        let mut pid_le = pid.to_le_bytes();
+        pid_uid_gid[0..4].swap_with_slice(&mut pid_le);
+
+        // region: extractMSysGitUID
+        let vec_byte_out = std::process::Command::new(r#"C:\Program Files\Git\usr\bin\bash.exe"#)
+            .arg("-c")
+            .arg("ps")
+            .output()?
+            .stdout;
+        let string_output = String::from_utf8_lossy(&vec_byte_out);
+
+        let capture_uid = regex::Regex::new(r#"(?m)^\s+\d+\s+\d+\s+\d+\s+\d+\s+\?\s+(\d+)"#)
+            .map_err(|_| {
+                Error::GitBashErrorMessage("Format of 'bash.exe -c ps' is incorrect.".to_string())
+            })?;
+        let first_capture = capture_uid.captures(&string_output).ok_or_else(|| {
+            Error::GitBashErrorMessage("Format of 'bash.exe -c ps' is incorrect.".to_string())
+        })?;
+        let first_capture_str = first_capture
+            .get(1)
+            .ok_or_else(|| {
+                Error::GitBashErrorMessage("Format of 'bash.exe -c ps' is incorrect.".to_string())
+            })?
+            .as_str();
+        let uid: u32 = first_capture_str.parse().map_err(|_| {
+            Error::GitBashErrorMessage("Format of 'bash.exe -c ps' is incorrect.".to_string())
+        })?;
+        // endregion: extractMSysGitUID
+
+        let mut uid_le = uid.to_le_bytes();
+        pid_uid_gid[4..8].swap_with_slice(&mut uid_le);
+
+        // for cygwin's AF_UNIX -> AF_INET, pid = gid"
+        let gid = pid;
+        let mut gid_le = gid.to_le_bytes();
+        pid_uid_gid[8..12].swap_with_slice(&mut gid_le);
+
+        let _amount = tcp_stream.write(&pid_uid_gid)?;
+
+        let mut b3: [u8; 16] = [0; 16];
+        let _amount = tcp_stream.read(&mut b3)?;
+
+        let socket = Box::new(tcp_stream);
+        Ok(Client { socket })
     }
 }
 


### PR DESCRIPTION
Windows has many different and not compatible ssh-agent implementations.  It is confusing.

1. git-bash openssh works over Tcp sockets and is the most similar to the Linux implementation
2. Microsoft own implementation openssh works over named pipes and is not 100% compatible.
3. After 2019 Microsoft introduced its own implementation of Unix Sockets that are not 100% compatible.
4. Oldest msys or msysGit implementations are obsolete and deprecated

Here we are talking only about the implementation of ssh-agent inside windows git-bash.
Windows git-bash environment has also other names: cygwin, msys2, mingW64, git-for-windows, msys and msysgit.  
This environment provides functionality similar to a Linux distribution directly inside the Windows OS. 
This implementation works over Tcp socket instead of Unix socket. 
It has a strange handshake with changing orders of bytes of some keys to spice things up. 

Here is the discussion and implementation code:
<https://stackoverflow.com/questions/23086038/what-mechanism-is-used-by-msys-cygwin-to-emulate-unix-domain-sockets>
<https://github.com/abourget/secrets-bridge/blob/master/pkg/agentfwd/agentconn_windows.go>

I ported this solution to Rust. 
I installed Rust into my windows git-bash environment:

```plaintext
<https://www.reddit.com/r/rust/comments/197zxwx/rust_and_msys2_on_windows/>
Go to https://rustup.rs
Inside git-bash run the incantation for Linux to install Rust.
Choose the GNU toolchain flavour when prompted (twice).
Restart the git-bash for the change in PATH to take effect.
You can use cargo as normal both inside and outside of msys2.
While inside msys2 it will be able to find any deps you've installed there.
```

There I tested the solution with my projects. 


I added a github action to build and test commits in windows for the target x86_64-pc-windows-gnu. 
There are no errors or warnings.

Just to mention I edited a 'static return type because it was a warning from the compiler.
And I added an empty line in README.md after "Licensed under.." because it was a warning from VSCode.  
The text in README and comments could be better, I am not a native english speaker and the terminology is sometimes confusing.
I added 2 dependencies in Cargo.toml for regex and sscanf. It would not be hard to refactor the code to avoid these 2 added dependencies.

I am happy to discuss with you about changes to make this Pull Request a good contribution to your project.
