### PR TITLE
Add a blanket implementation of the ReadWrite trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,7 @@ pub struct Client {
     socket: Box<dyn ReadWrite>,
 }
 
-#[cfg(target_family = "unix")]
-impl ReadWrite for UnixStream {}
+impl<T> ReadWrite for T where T: Read + Write {}
 
 #[cfg(target_family = "windows")]
 impl ReadWrite for DuplexPipeStream<pipe_mode::Bytes> {}

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -1,4 +1,3 @@
-use ssh_agent_client_rs::ReadWrite;
 use std::io::{Cursor, Read, Write};
 
 pub struct MockSocket<'a> {
@@ -28,8 +27,6 @@ impl Drop for MockSocket<'_> {
         assert_eq!(self.expected, self.output.as_slice())
     }
 }
-
-impl ReadWrite for MockSocket<'_> {}
 
 impl<'a> MockSocket<'a> {
     pub fn new(expected: &'a [u8], response: &'a [u8]) -> MockSocket<'a> {


### PR DESCRIPTION
With this blanked implementation, the ssh-agent-client can wrap any type that implements Read + Write enabling other transport implementations such as nework sockets without the need to modify this library to have those transports explicitly implemnet ReadWrite.