### PR TITLE
Add support SSH certificates

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,3 +1,4 @@
+use ssh_agent_client_rs::Identity;
 use ssh_agent_client_rs::{Client, Result};
 use ssh_key::public::PublicKey;
 use std::env;
@@ -9,7 +10,7 @@ use std::path::Path;
 fn main() -> Result<()> {
     let path = env::var("SSH_AUTH_SOCK").expect("SSH_AUTH_SOCK is not set");
     let mut client = Client::connect(Path::new(path.as_str()))?;
-    let identities = client.list_identities()?;
+    let identities = client.list_all_identities()?;
     if identities.len() < 1 {
         println!("The agent has no identities.");
     } else {
@@ -18,7 +19,21 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn print(key: &PublicKey) {
+fn print(identity: &Identity) {
+    match identity {
+        Identity::PublicKey(key) => print_pubkey(&key),
+        Identity::Certificate(cert) => print_certificate(&cert),
+    }
+}
+fn print_certificate(cert: &ssh_key::Certificate) {
+    println!(
+        "{} {} {}",
+        cert.public_key().fingerprint(Default::default()),
+        cert.comment(),
+        cert.algorithm().to_string(),
+    );
+}
+fn print_pubkey(key: &PublicKey) {
     println!(
         "{} {} {}",
         key.fingerprint(Default::default()),


### PR DESCRIPTION
This adds minimal support for SSH certificates into the library.
It introduces a wrapper around the two possible types and also adds a new signature method to make signing with certificates also possible.

Added a fix in order to properly handle agents with certificates irrespective of the order they have been inserted into the agent.
Added a few test cases too.