### PR TITLE
Un-deprecate sign(), change naming sign_with_ref()

### DIFF
--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -1,7 +1,7 @@
 use bytes::BytesMut;
 use rand::{rng, RngCore};
 use signature::Verifier;
-use ssh_agent_client_rs::{Client, Result};
+use ssh_agent_client_rs::{Client, Identity, Result};
 use ssh_key::public::KeyData;
 use ssh_key::{Certificate, PublicKey, Signature};
 use std::env;
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
         .nth(2)
         .unwrap_or_else(|| String::from("public_key"));
 
-    let identity = &match key_type.as_str() {
+    let identity: &Identity = &match key_type.as_str() {
         "certificate" => {
             println!("Using a certificate");
             Certificate::from_openssh(path_or_certificate.as_str())
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
     rng().fill_bytes(&mut data);
     let data = data.freeze();
 
-    let sig = client.sign_with_identity(identity, &data)?;
+    let sig = client.sign_with_ref(identity, &data)?;
     verify_signature(identity.into(), &data, &sig)?;
     Ok(())
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -43,9 +43,7 @@ fn test_sign_with_identity() {
 
     let mut client = Client::with_read_write(Box::new(socket));
 
-    let result = client
-        .sign_with_identity(&pubkey_identity, TEST_DATA)
-        .unwrap();
+    let result = client.sign(pubkey_identity, TEST_DATA).unwrap();
 
     assert_eq!(private_key.key_data().sign(TEST_DATA.as_ref()), result);
 }
@@ -57,14 +55,10 @@ fn test_sign_remote_failure() {
         include_bytes!("data/failure_response.bin"),
     );
 
-    let public_key = PublicKey::from_openssh(include_str!("data/id_ed25519.pub"))
-        .unwrap()
-        .into();
+    let public_key = PublicKey::from_openssh(include_str!("data/id_ed25519.pub")).unwrap();
 
     let mut client = Client::with_read_write(Box::new(socket));
-    let result = client
-        .sign_with_identity(&public_key, TEST_DATA)
-        .unwrap_err();
+    let result = client.sign(&public_key, TEST_DATA).unwrap_err();
     assert!(matches!(result, Error::RemoteFailure));
 }
 
@@ -75,12 +69,10 @@ fn test_sign_invalid_response() {
         include_bytes!("data/sign_request.bin"),
     );
 
-    let identity = PublicKey::from_openssh(include_str!("data/id_ed25519.pub"))
-        .unwrap()
-        .into();
+    let key = PublicKey::from_openssh(include_str!("data/id_ed25519.pub")).unwrap();
 
     let mut client = Client::with_read_write(Box::new(socket));
-    let result = client.sign_with_identity(&identity, TEST_DATA).unwrap_err();
+    let result = client.sign(&key, TEST_DATA).unwrap_err();
     match result {
         Error::UnknownMessageType(_) => {}
         result => panic!("{}", result),


### PR DESCRIPTION
Made Identity hold Box<Cow<>> instances for its variants instead of just Box<>, which enables holding a reference when that is what you pass in, avoiding needless copying.

I realised that most users of the signing API would probably just hold either a PublicKey or a Certificate, in which case the sign() signature makes complete sense. Calling it with a &PublicKey or &Certificate will do the right thing, and the cost of creating an Identity instance presumably very small. For the case where some calling code holds an Identity, it makes sense that one might not want that Identity to be needlessly moved into sign(), so for this case a separate method `sign_with_ref()` makes sense so that this value can be borrowed.

