### PR TITLE
Have Client::list_all_identities() return 'static lifetimed value

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -37,10 +37,10 @@ pub enum WriteMessage<'a> {
 }
 
 #[derive(Debug)]
-pub enum ReadMessage<'a> {
+pub enum ReadMessage {
     Failure,
     Success,
-    Identities(Vec<Identity<'a>>),
+    Identities(Vec<Identity<'static>>),
     Signature(Signature),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ impl<'a> Client {
         })
     }
     /// List the identities that have been added to the connected ssh-agent including certs.
-    pub fn list_all_identities(&mut self) -> Result<Vec<Identity>> {
+    pub fn list_all_identities(&mut self) -> Result<Vec<Identity<'static>>> {
         write_message(&mut self.socket, WriteMessage::RequestIdentities)?;
         match read_message(&mut self.socket)? {
             ReadMessage::Identities(identities) => Ok(identities),


### PR DESCRIPTION
Since list_all_identities() takes a &mut self reference, previously that meant that the mutable borrow would need to live for as long as the returned values lived. Since the implementation of list_all_identities() only returns the Cow::Owned variant and as such don't even hold borrowed values, this was a bit frustrating.

It seems like the received wisdom is that if the value returned has the 'static lifetime, this resolves the problem.