### PR TITLE
Some smaller fixes

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -13,17 +13,19 @@ fn main() -> Result<()> {
     if identities.is_empty() {
         println!("The agent has no identities.");
     } else {
-        identities.iter().for_each(print);
+        for identity in identities {
+            println!("{}", to_string(&identity)?);
+        }
     }
     Ok(())
 }
 
-fn print(identity: &Identity) {
+fn to_string(identity: &Identity) -> Result<String> {
     let (public_key, comment, suffix) = match identity {
         Identity::PublicKey(key) => (key.key_data(), key.comment(), ""),
         Identity::Certificate(cert) => (cert.public_key(), cert.comment(), "-cert"),
     };
     let fingerprint = public_key.fingerprint(Default::default());
     let algo = public_key.algorithm();
-    println!("{fingerprint} {comment} {algo}{suffix}")
+    Ok(format!("{fingerprint} {comment} {algo}{suffix}"))
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -91,7 +91,7 @@ pub fn write_message(output: &mut dyn Write, message: WriteMessage) -> Result<()
                     buf.write_all(data)?;
                     // Emit signature flags, see the spec section 4.5.1
                     match key.algorithm() {
-                        // Let's always use the SHA2 512 bit hash when signing RSA keys, to simplify the API
+                        // Let's always use the SHA2 512-bit hash when signing RSA keys, to simplify the API
                         Algorithm::Rsa { hash: _ } => write_u32(SSH_AGENT_RSA_SHA2_512, &mut buf)?,
                         _ => write_u32(0, &mut buf)?,
                     }
@@ -124,7 +124,7 @@ fn write_u32(i: usize, output: &mut dyn Write) -> Result<()> {
 fn read_packet(mut input: impl Read) -> Result<(MessageTypeId, Bytes)> {
     let mut buf = [0u8; 5];
     input.read_exact(&mut buf)?;
-    let mut buf = &buf[..];
+    let mut buf = buf.as_ref();
     let len = buf.get_length()?;
     let message_type = buf.get_u8();
 
@@ -153,31 +153,30 @@ fn make_identities<'a>(mut buf: Bytes) -> Result<Vec<Identity<'a>>> {
         if get_key_type(key_bytes)?.contains("-cert-") {
             let cert = Certificate::from_bytes(key_bytes)?;
             buf.advance(key_len);
-            let comment_len = buf.get_length()?;
-            let comment = &buf.chunk()[..comment_len];
-            let comment = std::str::from_utf8(comment).unwrap().to_string();
-            buf.advance(comment_len);
             // There are no setter for the adding the comment to the certificate after
             // it has been created, so we have to encode it again.
             // This is not ideal, but it is the way it is for now.
-            let mut encoded_cert = cert.to_openssh()?;
-            encoded_cert.push(' ');
-            encoded_cert.push_str(&comment);
+            let encoded_cert = format!("{} {}", cert.to_openssh()?, get_comment(&mut buf)?);
             let cert_with_comment = Certificate::from_openssh(&encoded_cert)?;
             result.push(cert_with_comment.into());
         } else {
             let mut public_key = PublicKey::from_bytes(&buf.chunk()[..key_len])?;
             buf.advance(key_len);
-            let comment_len = buf.get_length()?;
-            let comment = &buf.chunk()[..comment_len];
-            let comment = std::str::from_utf8(comment).unwrap().to_string();
-            buf.advance(comment_len);
-
-            public_key.set_comment(comment);
+            public_key.set_comment(get_comment(&mut buf)?);
             result.push(public_key.into());
         }
     }
     Ok(result)
+}
+
+fn get_comment(buf: &mut Bytes) -> Result<String> {
+    let comment_len = buf.get_length()?;
+    let result = match std::str::from_utf8(&buf.chunk()[..comment_len]) {
+        Ok(comment) => Ok(comment.to_string()),
+        Err(_) => return invalid_data("Invalid utf-8 sequence in comment"),
+    };
+    buf.advance(comment_len);
+    result
 }
 
 fn get_key_type(bytes: &[u8]) -> Result<String> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,18 +11,24 @@ pub enum Error {
     /// A message with an unknown type field was received.
     #[error("Received an unknown message type: {0}")]
     UnknownMessageType(u8),
+
     /// There was a failure parsing the message
     #[error("An invalid message was received: {0}")]
     InvalidMessage(String),
+
     /// There was an io::Error communicating with the agent
     #[error("An error occurred communicating with the agent")]
     AgentCommunicationError(#[from] std::io::Error),
-    /// An operation returned a ssh_key::Error wrapped in this variant.
+
+    /// An operation returned an ssh_key::Error wrapped in this variant.
     #[error("An ssh key operation failed")]
     SSHKey(#[from] ssh_key::Error),
+
+    /// There was a failure to decode or encode an SSH key or certificate.
     #[error("An ssh encoding operation failed")]
     SSHEncoding(#[from] ssh_encoding::Error),
-    #[error("The remote ssh agent returned the failure message")]
+
     /// An operation returned the Failure message from the remote ssh-agent.
+    #[error("The remote ssh agent returned the failure message")]
     RemoteFailure,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@ pub use self::error::Result;
 /// A combination of the std::io::Read and std::io::Write traits.
 pub trait ReadWrite: Read + Write {}
 
+/// Blanket implementation of ReadWrite for all types that implement both Read and Write.
+/// This makes things such as sockets and files compatible with the ReadWrite abstraction
+impl<T> ReadWrite for T where T: Read + Write {}
+
 /// A Client instance is an object that can be used to interact with an ssh-agent,
 /// typically using a Unix socket
 pub struct Client {
@@ -83,8 +87,6 @@ impl<'a> From<&'a Identity<'a>> for &'a KeyData {
         }
     }
 }
-
-impl<T> ReadWrite for T where T: Read + Write {}
 
 impl<'a> Client {
     /// Constructs a Client connected to a unix socket referenced by path.

--- a/tests/data/create.sh
+++ b/tests/data/create.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+# usage: bash -x ./create.sh
 # This script details how the test files were created. The ssh-keygen, ssh-add
 # used are the ones shipping with macOS, socat is installed through Homebrew.
 


### PR DESCRIPTION
- Removed the shebang from create.sh that works around the rpm packaging tooling that previously introduced a spurious dependency on bash.
- Refactor parsing of key and cert comments, no longer panic!() on malformed UTF-8 sequences in ssh key comments.
- Some minor documentation updates
- Output formatting in the examples