### PR TITLE
Make key algorithms and Windows transport optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,16 @@ Pure rust implementation of the ssh-agent protocol. It can be used to write clie
 edition = "2024"
 rust-version = "1.85.1"
 
+[features]
+default = ["all-key-algorithms", "windows-named-pipe"]
+all-key-algorithms = ["ssh-key/crypto"]
+ed25519 = ["ssh-key/ed25519"]
+ignore-unsupported-identities = []
+windows-named-pipe = ["dep:interprocess"]
+
 [dependencies]
 bytes = "1.11"
-ssh-key = { version = "0.6", features = ["crypto"] }
+ssh-key = { version = "0.6", default-features = false, features = ["std"] }
 ssh-encoding = "0.2"
 signature = "2.2"
 thiserror = "2.0"
@@ -21,4 +28,4 @@ rand = "0.9"
 anyhow = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-interprocess = "2.2"
+interprocess = { version = "2.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The basic idea is to create a `Client` instance and call its public methods to i
 ## Windows support
 
 Support for communicating with the `openssh-ssh-agent` shipped with Windows 11 is implemented using
-named pipes and the `interprocess` crate. To try the various example binaries, first set the `SSH_AUTH_SOCK`
+named pipes and the `interprocess` crate. It is enabled by the default
+`windows-named-pipe` feature and can be omitted by Unix-only consumers. To try the various example binaries, first set the `SSH_AUTH_SOCK`
 variable as follows:
 ```cmd
 > set SSH_AUTH_SOCK=\\.\pipe\openssh-ssh-agent
@@ -48,6 +49,15 @@ variable as follows:
 
 If you are using the ssh-agent shipped with [git for windows](https://gitforwindows.org/) you might need to
 use the Unix socket emulation implementation available from https://github.com/bestia-dev/ssh_agent_client_rs_git_bash
+
+## Algorithm features
+
+The default `all-key-algorithms` feature preserves support for all algorithms
+handled by `ssh-key`. Consumers with a closed algorithm profile can disable
+default features and enable only the required algorithm, such as `ed25519`.
+When a shared agent may expose other key types, the
+`ignore-unsupported-identities` feature skips identities whose algorithm was
+not compiled in while retaining malformed-message failures.
 
 ## License
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -168,21 +168,29 @@ fn make_identities<'a>(mut buf: Bytes) -> Result<Vec<Identity<'a>>> {
         if key_len > buf.len() {
             return invalid_data("buffer too short");
         }
-        let key_bytes = &buf.chunk()[..key_len];
-        if get_key_type(key_bytes)?.contains("-cert-") {
-            let cert = Certificate::from_bytes(key_bytes)?;
-            buf.advance(key_len);
-            // There is no setter for adding the comment to the certificate after
-            // it has been created, so we have to encode it again.
-            // This is not ideal, but it is the way it is for now.
-            let encoded_cert = format!("{} {}", cert.to_openssh()?, get_comment(&mut buf)?);
-            let cert_with_comment = Certificate::from_openssh(&encoded_cert)?;
-            result.push(cert_with_comment.into());
+        let key_bytes = buf.split_to(key_len);
+        let is_certificate = get_key_type(&key_bytes)?.contains("-cert-");
+        let comment = get_comment(&mut buf)?;
+        let identity = if is_certificate {
+            Certificate::from_bytes(&key_bytes)
+                .and_then(|cert| {
+                    // There is no setter for adding the comment to the certificate after
+                    // it has been created, so we have to encode it again.
+                    let encoded_cert = format!("{} {comment}", cert.to_openssh()?);
+                    Certificate::from_openssh(&encoded_cert)
+                })
+                .map(Identity::from)
         } else {
-            let mut public_key = PublicKey::from_bytes(&buf.chunk()[..key_len])?;
-            buf.advance(key_len);
-            public_key.set_comment(get_comment(&mut buf)?);
-            result.push(public_key.into());
+            PublicKey::from_bytes(&key_bytes).map(|mut public_key| {
+                public_key.set_comment(comment);
+                Identity::from(public_key)
+            })
+        };
+        match identity {
+            Ok(identity) => result.push(identity),
+            #[cfg(feature = "ignore-unsupported-identities")]
+            Err(ssh_key::Error::AlgorithmUnknown) => {}
+            Err(error) => return Err(error.into()),
         }
     }
     Ok(result)
@@ -376,6 +384,27 @@ mod test {
         } else {
             panic!("did not receive expected public key");
         }
+        Ok(())
+    }
+
+    #[cfg(all(
+        feature = "ignore-unsupported-identities",
+        not(feature = "all-key-algorithms")
+    ))]
+    #[test]
+    fn feature_limited_client_ignores_only_unsupported_algorithms() -> Result<(), Error> {
+        let data = Bytes::from_static(include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/data/identities_with_cert.bin"
+        )));
+        let identities = make_identities(data)?;
+        assert_eq!(2, identities.len());
+        assert!(identities.iter().all(|identity| match identity {
+            Identity::PublicKey(key) => key.algorithm().as_str() == "ssh-ed25519",
+            Identity::Certificate(certificate) => {
+                certificate.public_key().algorithm().as_str() == "ssh-ed25519"
+            }
+        }));
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```
 
 use crate::codec::{ReadMessage, WriteMessage, read_message, write_message};
-#[cfg(target_family = "windows")]
+#[cfg(all(target_family = "windows", feature = "windows-named-pipe"))]
 use interprocess::os::windows::named_pipe::{DuplexPipeStream, pipe_mode};
 use ssh_key::public::KeyData;
 use ssh_key::{Certificate, PrivateKey, PublicKey, Signature};
@@ -98,7 +98,7 @@ impl<'a> Client {
 
     // If you want to communicate with the ssh-agent shipped with windows you probably want to pass
     // Path::new(r"\\.\pipe\openssh-ssh-agent")
-    #[cfg(target_family = "windows")]
+    #[cfg(all(target_family = "windows", feature = "windows-named-pipe"))]
     pub fn connect(path: &Path) -> Result<Client> {
         let pipe = DuplexPipeStream::<pipe_mode::Bytes>::connect_by_path(path)?;
         Ok(Client {


### PR DESCRIPTION
## Summary

- preserve the current all-algorithm and Windows behavior as default features
- let Unix consumers compile only Ed25519 and omit the Windows named-pipe dependency
- optionally ignore identities for algorithms that were deliberately not compiled in while still rejecting malformed messages

## Motivation

Closed-algorithm consumers currently pull the full `ssh-key/crypto` graph, including unused RSA implementations, and Unix-only consumers retain the Windows transport graph in their lockfile. The new features keep existing behavior by default while allowing a narrower auditable dependency graph.

## Verification

- `cargo test --all-targets`
- `cargo test --lib feature_limited_client_ignores_only_unsupported_algorithms --no-default-features --features ed25519,ignore-unsupported-identities`
- `cargo check --lib --no-default-features --features ed25519,ignore-unsupported-identities`